### PR TITLE
Fjernet sjekk om Person er lik List<Person>

### DIFF
--- a/no.hal.jex.collection/tests/objectstructures/Person.jextest
+++ b/no.hal.jex.collection/tests/objectstructures/Person.jextest
@@ -86,8 +86,7 @@ sequence morskapAddChild "Marit er mor til Jens og Anne" {
 
 method boolean == (Person person, Pair<Pair<?, ?>, List<?>> fatherMotherChildren) {
 	if (! (person.father == fatherMotherChildren.key.key &&
-			person.mother == fatherMotherChildren.key.value &&
-			person == fatherMotherChildren.value)) {
+			person.mother == fatherMotherChildren.key.value)) {
 				return false
 	}
 	val children = fatherMotherChildren.value


### PR DESCRIPTION
Det var en linje som sjekket om Personen som blir testet var lik listen av barna den skulle ha.

Det skal ikke finnes en equals-metode mellom Person og List<Person>, da de representerer forsellige ting. Siden den ikke finnes, slo testene alltid ut som feil.
