### PR TITLE
StringMergeIterator, en med feil og en uten

### DIFF
--- a/no.hal.jex.collection/src-gen/interfaces/StringMergingIteratorTest.java
+++ b/no.hal.jex.collection/src-gen/interfaces/StringMergingIteratorTest.java
@@ -1,0 +1,291 @@
+package interfaces;
+
+import interfaces.StringMergingIterator;
+import java.util.ArrayList;
+import java.util.Iterator;
+import junit.framework.TestCase;
+import no.hal.jex.runtime.JExercise;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+
+@JExercise(description = "Tests interfaces.StringMergingIterator")
+@SuppressWarnings("all")
+public class StringMergingIteratorTest extends TestCase {
+  private Iterator<String> first;
+  
+  private Iterator<String> _init_first() {
+    ArrayList<String> _newArrayList = CollectionLiterals.<String>newArrayList("a", "b");
+    Iterator<String> _iterator = _newArrayList.iterator();
+    return _iterator;
+  }
+  
+  private Iterator<String> second;
+  
+  private Iterator<String> _init_second() {
+    ArrayList<String> _newArrayList = CollectionLiterals.<String>newArrayList("c", "d");
+    Iterator<String> _iterator = _newArrayList.iterator();
+    return _iterator;
+  }
+  
+  private Iterator<String> empty1;
+  
+  private Iterator<String> _init_empty1() {
+    ArrayList<String> _newArrayList = CollectionLiterals.<String>newArrayList();
+    Iterator<String> _iterator = _newArrayList.iterator();
+    return _iterator;
+  }
+  
+  private Iterator<String> empty2;
+  
+  private Iterator<String> _init_empty2() {
+    ArrayList<String> _newArrayList = CollectionLiterals.<String>newArrayList();
+    Iterator<String> _iterator = _newArrayList.iterator();
+    return _iterator;
+  }
+  
+  @Override
+  protected void setUp() {
+    first = _init_first();
+    second = _init_second();
+    empty1 = _init_empty1();
+    empty2 = _init_empty2();
+    
+  }
+  
+  @JExercise(tests = "StringMergingIterator(java.util.Iterator<String>,java.util.Iterator<String>);boolean hasNext();String next()", description = "Tests \n\t\tthe following sequence:\n\t\t<ul>\n\t\t<li>mergingIterator.hasNext, mergingIterator.next==\"a\"</li>\n\t\t<li>mergingIterator.hasNext, mergingIterator.next==\"c\"</li>\n\t\t<li>mergingIterator.hasNext, mergingIterator.next==\"b\"</li>\n\t\t<li>mergingIterator.hasNext, mergingIterator.next==\"d\"</li>\n\t\t</ul>\n")
+  public void testMergeLists() {
+    StringMergingIterator mergingIterator = _init__mergeLists_mergingIterator();
+    _transition_exprAction__mergeLists_transitions0_actions0(mergingIterator);
+    _transition_exprAction__mergeLists_transitions0_actions1(mergingIterator);
+    _test__mergeLists_transitions0_effect_state(mergingIterator);
+    _transition_exprAction__mergeLists_transitions1_actions0(mergingIterator);
+    _transition_exprAction__mergeLists_transitions1_actions1(mergingIterator);
+    _test__mergeLists_transitions1_effect_state(mergingIterator);
+    _transition_exprAction__mergeLists_transitions2_actions0(mergingIterator);
+    _transition_exprAction__mergeLists_transitions2_actions1(mergingIterator);
+    _test__mergeLists_transitions2_effect_state(mergingIterator);
+    _transition_exprAction__mergeLists_transitions3_actions0(mergingIterator);
+    _transition_exprAction__mergeLists_transitions3_actions1(mergingIterator);
+    _test__mergeLists_transitions3_effect_state(mergingIterator);
+    
+  }
+  
+  @JExercise(tests = "StringMergingIterator(java.util.Iterator<String>,java.util.Iterator<String>);boolean hasNext();String next()", description = "Tests \n\t\tthe following sequence:\n\t\t<ul>\n\t\t<li>mergingIterator.hasNext, mergingIterator.next==\"a\"</li>\n\t\t<li>mergingIterator.hasNext, mergingIterator.next==\"b\"</li>\n\t\t</ul>\n")
+  public void testMergeOneEmpty() {
+    StringMergingIterator mergingIterator = _init__mergeOneEmpty_mergingIterator();
+    _transition_exprAction__mergeOneEmpty_transitions0_actions0(mergingIterator);
+    _transition_exprAction__mergeOneEmpty_transitions0_actions1(mergingIterator);
+    _test__mergeOneEmpty_transitions0_effect_state(mergingIterator);
+    _transition_exprAction__mergeOneEmpty_transitions1_actions0(mergingIterator);
+    _transition_exprAction__mergeOneEmpty_transitions1_actions1(mergingIterator);
+    _test__mergeOneEmpty_transitions1_effect_state(mergingIterator);
+    
+  }
+  
+  @JExercise(tests = "StringMergingIterator(java.util.Iterator<String>,java.util.Iterator<String>)", description = "Tests \n\t\tinitialization\n")
+  public void testMergeBothEmpty() {
+    StringMergingIterator mergingIterator = _init__mergeBothEmpty_mergingIterator();
+    _test__mergeBothEmpty_transitions0_effect_state(mergingIterator);
+    
+  }
+  
+  private StringMergingIterator _init__mergeLists_mergingIterator() {
+    StringMergingIterator _stringMergingIterator = new StringMergingIterator(this.first, this.second);
+    return _stringMergingIterator;
+  }
+  
+  private void _transition_exprAction__mergeLists_transitions0_actions0(final StringMergingIterator mergingIterator) {
+    try {
+      
+      mergingIterator.hasNext();
+      } catch (junit.framework.AssertionFailedError error) {
+      fail("mergingIterator.hasNext failed: " + error.getMessage());
+    }
+    
+  }
+  
+  private void _transition_exprAction__mergeLists_transitions0_actions1(final StringMergingIterator mergingIterator) {
+    
+    String _next = mergingIterator.next();
+    assertEquals("mergingIterator.next==\"a\" failed", "a", _next);
+    
+  }
+  
+  private void _test__mergeLists_transitions0_effect_state(final StringMergingIterator mergingIterator) {
+    _test__mergeLists_transitions0_effect_state_objectTests0_test(mergingIterator);
+    
+  }
+  
+  private void _test__mergeLists_transitions0_effect_state_objectTests0_test(final StringMergingIterator mergingIterator) {
+    
+    assertTrue("mergingIterator.hasNext failed after mergingIterator.hasNext ,mergingIterator.next==\"a\"", mergingIterator.hasNext());
+    
+  }
+  
+  private void _transition_exprAction__mergeLists_transitions1_actions0(final StringMergingIterator mergingIterator) {
+    try {
+      
+      mergingIterator.hasNext();
+      } catch (junit.framework.AssertionFailedError error) {
+      fail("mergingIterator.hasNext failed: " + error.getMessage());
+    }
+    
+  }
+  
+  private void _transition_exprAction__mergeLists_transitions1_actions1(final StringMergingIterator mergingIterator) {
+    
+    String _next = mergingIterator.next();
+    assertEquals("mergingIterator.next==\"c\" failed", "c", _next);
+    
+  }
+  
+  private void _test__mergeLists_transitions1_effect_state(final StringMergingIterator mergingIterator) {
+    _test__mergeLists_transitions1_effect_state_objectTests0_test(mergingIterator);
+    
+  }
+  
+  private void _test__mergeLists_transitions1_effect_state_objectTests0_test(final StringMergingIterator mergingIterator) {
+    
+    assertTrue("mergingIterator.hasNext failed after mergingIterator.hasNext ,mergingIterator.next==\"c\"", mergingIterator.hasNext());
+    
+  }
+  
+  private void _transition_exprAction__mergeLists_transitions2_actions0(final StringMergingIterator mergingIterator) {
+    try {
+      
+      mergingIterator.hasNext();
+      } catch (junit.framework.AssertionFailedError error) {
+      fail("mergingIterator.hasNext failed: " + error.getMessage());
+    }
+    
+  }
+  
+  private void _transition_exprAction__mergeLists_transitions2_actions1(final StringMergingIterator mergingIterator) {
+    
+    String _next = mergingIterator.next();
+    assertEquals("mergingIterator.next==\"b\" failed", "b", _next);
+    
+  }
+  
+  private void _test__mergeLists_transitions2_effect_state(final StringMergingIterator mergingIterator) {
+    _test__mergeLists_transitions2_effect_state_objectTests0_test(mergingIterator);
+    
+  }
+  
+  private void _test__mergeLists_transitions2_effect_state_objectTests0_test(final StringMergingIterator mergingIterator) {
+    
+    assertTrue("mergingIterator.hasNext failed after mergingIterator.hasNext ,mergingIterator.next==\"b\"", mergingIterator.hasNext());
+    
+  }
+  
+  private void _transition_exprAction__mergeLists_transitions3_actions0(final StringMergingIterator mergingIterator) {
+    try {
+      
+      mergingIterator.hasNext();
+      } catch (junit.framework.AssertionFailedError error) {
+      fail("mergingIterator.hasNext failed: " + error.getMessage());
+    }
+    
+  }
+  
+  private void _transition_exprAction__mergeLists_transitions3_actions1(final StringMergingIterator mergingIterator) {
+    
+    String _next = mergingIterator.next();
+    assertEquals("mergingIterator.next==\"d\" failed", "d", _next);
+    
+  }
+  
+  private void _test__mergeLists_transitions3_effect_state(final StringMergingIterator mergingIterator) {
+    _test__mergeLists_transitions3_effect_state_objectTests0_test(mergingIterator);
+    
+  }
+  
+  private void _test__mergeLists_transitions3_effect_state_objectTests0_test(final StringMergingIterator mergingIterator) {
+    
+    boolean _hasNext = mergingIterator.hasNext();
+    assertTrue("! mergingIterator.hasNext failed after mergingIterator.hasNext ,mergingIterator.next==\"d\"", (!_hasNext));
+    
+  }
+  
+  private StringMergingIterator _init__mergeOneEmpty_mergingIterator() {
+    StringMergingIterator _stringMergingIterator = new StringMergingIterator(this.first, this.empty1);
+    return _stringMergingIterator;
+  }
+  
+  private void _transition_exprAction__mergeOneEmpty_transitions0_actions0(final StringMergingIterator mergingIterator) {
+    try {
+      
+      mergingIterator.hasNext();
+      } catch (junit.framework.AssertionFailedError error) {
+      fail("mergingIterator.hasNext failed: " + error.getMessage());
+    }
+    
+  }
+  
+  private void _transition_exprAction__mergeOneEmpty_transitions0_actions1(final StringMergingIterator mergingIterator) {
+    
+    String _next = mergingIterator.next();
+    assertEquals("mergingIterator.next==\"a\" failed", "a", _next);
+    
+  }
+  
+  private void _test__mergeOneEmpty_transitions0_effect_state(final StringMergingIterator mergingIterator) {
+    _test__mergeOneEmpty_transitions0_effect_state_objectTests0_test(mergingIterator);
+    
+  }
+  
+  private void _test__mergeOneEmpty_transitions0_effect_state_objectTests0_test(final StringMergingIterator mergingIterator) {
+    
+    assertTrue("mergingIterator.hasNext failed after mergingIterator.hasNext ,mergingIterator.next==\"a\"", mergingIterator.hasNext());
+    
+  }
+  
+  private void _transition_exprAction__mergeOneEmpty_transitions1_actions0(final StringMergingIterator mergingIterator) {
+    try {
+      
+      mergingIterator.hasNext();
+      } catch (junit.framework.AssertionFailedError error) {
+      fail("mergingIterator.hasNext failed: " + error.getMessage());
+    }
+    
+  }
+  
+  private void _transition_exprAction__mergeOneEmpty_transitions1_actions1(final StringMergingIterator mergingIterator) {
+    
+    String _next = mergingIterator.next();
+    assertEquals("mergingIterator.next==\"b\" failed", "b", _next);
+    
+  }
+  
+  private void _test__mergeOneEmpty_transitions1_effect_state(final StringMergingIterator mergingIterator) {
+    _test__mergeOneEmpty_transitions1_effect_state_objectTests0_test(mergingIterator);
+    
+  }
+  
+  private void _test__mergeOneEmpty_transitions1_effect_state_objectTests0_test(final StringMergingIterator mergingIterator) {
+    
+    boolean _hasNext = mergingIterator.hasNext();
+    assertTrue("! mergingIterator.hasNext failed after mergingIterator.hasNext ,mergingIterator.next==\"b\"", (!_hasNext));
+    
+  }
+  
+  private StringMergingIterator _init__mergeBothEmpty_mergingIterator() {
+    StringMergingIterator _stringMergingIterator = new StringMergingIterator(this.empty1, this.empty2);
+    return _stringMergingIterator;
+  }
+  
+  private void _test__mergeBothEmpty_transitions0_effect_state(final StringMergingIterator mergingIterator) {
+    _test__mergeBothEmpty_transitions0_effect_state_objectTests0_test(mergingIterator);
+    
+  }
+  
+  private void _test__mergeBothEmpty_transitions0_effect_state_objectTests0_test(final StringMergingIterator mergingIterator) {
+    
+    boolean _hasNext = mergingIterator.hasNext();
+    assertTrue("! mergingIterator.hasNext failed", (!_hasNext));
+    
+  }
+  
+  public static void main(final String[] args) {
+    no.hal.jex.standalone.JexStandalone.main(StringMergingIteratorTest.class);
+  }
+}

--- a/no.hal.jex.collection/src/debugging/StringMergingIterator.java
+++ b/no.hal.jex.collection/src/debugging/StringMergingIterator.java
@@ -1,4 +1,4 @@
-package interfaces;
+package debugging;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -30,7 +30,7 @@ public class StringMergingIterator implements Iterator<String> {
 		if(! first.hasNext()){
 			result = second.next();
 		} 
-		else if(! second.hasNext()){
+		else if(second.hasNext()){
 			result = first.next();
 		} 
 		else {
@@ -40,13 +40,11 @@ public class StringMergingIterator implements Iterator<String> {
 				result = second.next();
 			}
 			
-			turnSwitch = !turnSwitch;
+			turnSwitch = turnSwitch && false;
 		}
 		
 		return result;
-		
 	}
-	
 	
 	
 }

--- a/no.hal.jex.collection/src/debugging/StringMergingIterator.java
+++ b/no.hal.jex.collection/src/debugging/StringMergingIterator.java
@@ -28,10 +28,10 @@ public class StringMergingIterator implements Iterator<String> {
 		String result;
 		
 		if(! first.hasNext()){
-			result = second.next();
-		} 
-		else if(second.hasNext()){
 			result = first.next();
+		} 
+		else if(! second.hasNext()){
+			result = second.next();
 		} 
 		else {
 			if(turnSwitch){

--- a/no.hal.jex.collection/src/debugging/StringMergingIteratorProgram.java
+++ b/no.hal.jex.collection/src/debugging/StringMergingIteratorProgram.java
@@ -1,0 +1,40 @@
+package debugging;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+
+public class StringMergingIteratorProgram {
+
+	public static void main(String[] args) throws Exception {
+
+		Iterator<String> one = CollectionLiterals.<String>newArrayList("a", "b").iterator();
+		Iterator<String> two = CollectionLiterals.<String>newArrayList("c", "d", "e").iterator();
+		 
+		StringMergingIterator mergeIterator = new StringMergingIterator(one, two); 
+		
+		List<String> values = new ArrayList<String>();
+		
+		while(mergeIterator.hasNext()){
+			values.add(mergeIterator.next());
+		}
+		
+		List<String> expectedOutput = CollectionLiterals.<String>newArrayList("a", "c", "b", "d", "e");
+		
+		if(values.size() != expectedOutput.size()){
+			throw new Exception("The merged output did not contain the expected number of values. Try using the Eclipse debugger to see the difference between the lists.");
+		}
+		
+		for(int i = 0; i < expectedOutput.size(); i++){
+			if(! values.get(i).equals(expectedOutput.get(i))){
+				throw new Exception("The iterator did not correctly merge the output. Try using the Eclipse debugger to see the difference between the lists.");
+			}
+		}
+		
+		System.out.println("Success! StringMergingIterator correctly merged the output of the two lists.");
+		
+	}
+
+}

--- a/no.hal.jex.collection/src/interfaces/StringMergingIterator.java
+++ b/no.hal.jex.collection/src/interfaces/StringMergingIterator.java
@@ -1,0 +1,59 @@
+package interfaces;
+
+import java.util.Iterator;
+
+public class StringMergingIterator implements Iterator<String> {
+
+	private Iterator<String> first;
+	private Iterator<String> second;
+	
+	private String firstCurrent = null;
+	private String secondCurrent = null;
+
+	public StringMergingIterator(Iterator<String> first, Iterator<String> second){
+		this.first = first;
+		this.second = second;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return first.hasNext() || second.hasNext() || firstCurrent != null || secondCurrent != null; //her kan vi legge feil ved å kun ha de to første.
+	}
+
+	@Override
+	public String next() {
+		if(first.hasNext() && firstCurrent == null){
+			firstCurrent = first.next();
+		}
+		if(second.hasNext() && secondCurrent == null){
+			secondCurrent = second.next();
+		}
+		
+		String result;
+
+		if(firstCurrent == null){
+			result =  secondCurrent;
+			secondCurrent = null;
+		}
+		else if(secondCurrent == null){
+			result = firstCurrent;
+			firstCurrent = null;
+		}
+		else{
+			if(firstCurrent.compareTo(secondCurrent) > 0){
+				result = secondCurrent;                     //legg inn feil ved å endre til null før retur?
+				secondCurrent = null;
+			}
+			else{
+				result = firstCurrent;
+				firstCurrent = null;
+			}
+		}
+		
+		return result;
+		
+	}
+	
+	
+	
+}

--- a/no.hal.jex.collection/tests/interfaces/StringMergingIterator.jextest
+++ b/no.hal.jex.collection/tests/interfaces/StringMergingIterator.jextest
@@ -2,34 +2,30 @@ test interfaces.StringMergingIterator
 
 import java.util.Iterator
 
-instance Iterator<String> first = newArrayList("a","c").iterator
-instance Iterator<String> second = newArrayList("b","d").iterator
+instance Iterator<String> first = newArrayList("a","b").iterator
+instance Iterator<String> second = newArrayList("c","d").iterator
 instance Iterator<String> empty1 = newArrayList().iterator
 instance Iterator<String> empty2 = newArrayList().iterator
 
 
 sequence mergeLists {
 	instance mergingIterator = new StringMergingIterator(first, second)
-	-->
-	state {
-		mergingIterator.hasNext;
-		mergingIterator.next == "a";
-		mergingIterator.next == "b";
-		mergingIterator.next == "c";
-		mergingIterator.next == "d";
-		! mergingIterator.hasNext;			
-	}
+	-- mergingIterator.hasNext, mergingIterator.next=="a" -->
+	state { mergingIterator.hasNext; }
+	-- mergingIterator.hasNext, mergingIterator.next=="c" -->
+	state { mergingIterator.hasNext; }
+	-- mergingIterator.hasNext, mergingIterator.next=="b" -->
+	state { mergingIterator.hasNext; }
+	-- mergingIterator.hasNext, mergingIterator.next=="d" -->
+	state { ! mergingIterator.hasNext; }
 }
 
 sequence mergeOneEmpty {
 	instance mergingIterator = new StringMergingIterator(first, empty1)
-	-->
-	state {
-		mergingIterator.hasNext;
-		mergingIterator.next == "a";
-		mergingIterator.next == "c";
-		! mergingIterator.hasNext;			
-	}
+	-- mergingIterator.hasNext, mergingIterator.next=="a"-->
+	state { mergingIterator.hasNext; }
+	-- mergingIterator.hasNext, mergingIterator.next=="b"-->
+	state { ! mergingIterator.hasNext; }
 }
 
 sequence mergeBothEmpty{

--- a/no.hal.jex.collection/tests/interfaces/StringMergingIterator.jextest
+++ b/no.hal.jex.collection/tests/interfaces/StringMergingIterator.jextest
@@ -1,0 +1,41 @@
+test interfaces.StringMergingIterator
+
+import java.util.Iterator
+
+instance Iterator<String> first = newArrayList("a","c").iterator
+instance Iterator<String> second = newArrayList("b","d").iterator
+instance Iterator<String> empty1 = newArrayList().iterator
+instance Iterator<String> empty2 = newArrayList().iterator
+
+
+sequence mergeLists {
+	instance mergingIterator = new StringMergingIterator(first, second)
+	-->
+	state {
+		mergingIterator.hasNext;
+		mergingIterator.next == "a";
+		mergingIterator.next == "b";
+		mergingIterator.next == "c";
+		mergingIterator.next == "d";
+		! mergingIterator.hasNext;			
+	}
+}
+
+sequence mergeOneEmpty {
+	instance mergingIterator = new StringMergingIterator(first, empty1)
+	-->
+	state {
+		mergingIterator.hasNext;
+		mergingIterator.next == "a";
+		mergingIterator.next == "c";
+		! mergingIterator.hasNext;			
+	}
+}
+
+sequence mergeBothEmpty{
+	instance mergingIterator = new StringMergingIterator(empty1, empty2)
+	-->
+	state {
+		! mergingIterator.hasNext;			
+	}
+}


### PR DESCRIPTION
Har lagt til en korrekt implementasjon av en iterator som merger to String-iteratorer i interfaces, samt en jextest for denne klassen.

I tillegg laget jeg en debugging-mappe, hvor jeg la en variant av klassen hvor det er plantet feil samt et testprogram. Tanken bak å lage en ny mappe var å være konsistent med pakkestrukturen i dag, som kategoriserer oppgaver etter tema.
