### PR TITLE
CardComparatorTest and unmodifiableList

### DIFF
--- a/no.hal.jex.collection/src-gen/interfaces/CardComparatorTest.java
+++ b/no.hal.jex.collection/src-gen/interfaces/CardComparatorTest.java
@@ -70,7 +70,7 @@ public class CardComparatorTest extends TestCase {
   private List<Card> cards;
   
   private List<Card> _init_cards() {
-    return Collections.<Card>unmodifiableList(CollectionLiterals.<Card>newArrayList(this.s1, this.s13, this.h1, this.h13, this.d1, this.d13, this.c1, this.c13));
+    return CollectionLiterals.<Card>newArrayList(this.s1, this.s13, this.h1, this.h13, this.d1, this.d13, this.c1, this.c13);
   }
   
   @Override


### PR DESCRIPTION
The test for the CardComparator exercise contains a method
`private List<Card> _init_cards(){...}`

This method is used in the setUp method used for the setup of the each test. In each of the tests the list returned from the _init_cards method is called on with the sort method. This results in a crash with an UnsupportedOperationException which is caused by the fact that the sort method tries to modify a unmodifiable list. The crash also occurs both when trying to run the test on the code in the github repo and when trying to run the test on my own code for the exercise.
