### PR TITLE
Fix emfs code block detection when using IE as the internal browser

### DIFF
--- a/no.hal.confluence.ui/src/no/hal/confluence/ui/views/ConfluenceWikiView.java
+++ b/no.hal.confluence.ui/src/no/hal/confluence/ui/views/ConfluenceWikiView.java
@@ -3,7 +3,6 @@ package no.hal.confluence.ui.views;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/no.hal.confluence.ui/src/no/hal/confluence/ui/views/ConfluenceWikiView.java
+++ b/no.hal.confluence.ui/src/no/hal/confluence/ui/views/ConfluenceWikiView.java
@@ -1,5 +1,10 @@
 package no.hal.confluence.ui.views;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -174,7 +179,24 @@ public class ConfluenceWikiView extends ViewPart implements BrowserView, Locatio
 					s = domContent;
 				} else if (! domOnly) {
 					if (content == null) {
-						content = getContent();
+						// content = getContent();
+						// the following workaround is needed because when using IE as the
+						// internal browser, the HTML we receive from getContent() is not as expected
+						// thus we have to get it manually
+						try {
+							URL url = new URL(getLocation());
+							BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(url.openStream()));
+							StringBuilder contentBuilder = new StringBuilder();
+							String line = null;
+							while ((line = bufferedReader.readLine()) != null) {
+								contentBuilder.append(line);
+								contentBuilder.append('\n');
+							}
+							bufferedReader.close();
+							content = contentBuilder.toString();
+						} catch (IOException e) {
+							Activator.logError("Exception when getting web page source using a stream for " + resourceExtractor, e);
+						}
 					}
 					s = content;
 				}


### PR DESCRIPTION
When Internet Explorer is used as the internal browser in Eclipse, emfs code blocks are not detected and thus the files listed do not show up in the import view. The reason for this is that the HTML returned by the getContent method is from after any javascript on the page has run. Code blocks are wrapped in a script that substantially changes their HTML from what the parsing code expects. 

This fix avoids the problem by circumventing the internal browser and directly requesting the source code from the server. This should hopefully be platform independent. It works for me in Windows 8 and 10 and Ubuntu 15.10.
