### PR TITLE
Remove unused imports

### DIFF
--- a/no.hal.jex.collection/src/interfaces/twitter/TwitterAccount.java
+++ b/no.hal.jex.collection/src/interfaces/twitter/TwitterAccount.java
@@ -1,10 +1,8 @@
 package interfaces.twitter;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 
 public class TwitterAccount {

--- a/no.hal.jex.collection/src/rpn/RPNProgram.java
+++ b/no.hal.jex.collection/src/rpn/RPNProgram.java
@@ -1,6 +1,5 @@
 package rpn;
 
-import java.util.ArrayList;
 import java.util.Scanner;
 
 /*

--- a/no.hal.jex.collection/src/sokoban/sokoban3/Direction.java
+++ b/no.hal.jex.collection/src/sokoban/sokoban3/Direction.java
@@ -1,7 +1,5 @@
 package sokoban.sokoban3;
 
-import java.util.Arrays;
-
 public class Direction {
 
 	public final int dx, dy;

--- a/no.hal.jex.collection/src/stateandbehavior/Calc1Program.java
+++ b/no.hal.jex.collection/src/stateandbehavior/Calc1Program.java
@@ -1,8 +1,5 @@
 package stateandbehavior;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.Scanner;
 
 public class Calc1Program {

--- a/no.hal.jex.collection/src/tictactoe/tictactoe2/StandardLevelFormat.java
+++ b/no.hal.jex.collection/src/tictactoe/tictactoe2/StandardLevelFormat.java
@@ -6,8 +6,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.List;
 
 public class StandardLevelFormat implements LevelFormat {
 

--- a/no.hal.jex.collection/src/tictactoe/tictactoe3/StandardLevelFormat.java
+++ b/no.hal.jex.collection/src/tictactoe/tictactoe3/StandardLevelFormat.java
@@ -6,8 +6,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.List;
 
 public class StandardLevelFormat implements LevelFormat {
 

--- a/no.hal.jex.collection/tests/fraction/FractionTest.java
+++ b/no.hal.jex.collection/tests/fraction/FractionTest.java
@@ -4,7 +4,6 @@
  */
 package fraction;
 
-import fraction.Fraction;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 import no.hal.jex.runtime.JExercise;

--- a/no.hal.jex.collection/tests/tictactoe/AbstractExampleTest.java
+++ b/no.hal.jex.collection/tests/tictactoe/AbstractExampleTest.java
@@ -8,7 +8,6 @@ import java.util.Scanner;
 
 import junit.framework.TestCase;
 import no.hal.jex.runtime.CapturingSystemOutStream;
-import no.hal.jex.runtime.MultiFilterOutputStream;
 
 public abstract class AbstractExampleTest extends TestCase {
 


### PR DESCRIPTION
Removes a lot of unused imports, which results in warnings from most IDEs.
